### PR TITLE
fix: don't pass properties to createPage — it breaks Logseq's graph save and makes the app unquittable

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -292,12 +292,37 @@ async function create(page_title, page_properties, calibre_item) {
         await logseq.Editor.insertBlock(newBlock.uuid, `[${calibre_item.title}](calibre://show-book/${calibreLibrary}/${calibre_item.application_id})  {{renderer calibreViewer, special, /#book_id=${calibre_item.application_id}&fmt=${logseq.settings?.bookFormat}&library_id=${calibreLibrary}&mode=read_book}} {{renderer calibreHighlight, false, 2000, _, ${calibreLibrary}, ${calibre_item.application_id}, ${logseq.settings?.bookFormat}}}`);
     }
     else {
-        const newPage = await logseq.Editor.createPage(page_title, page_properties, {
+        // Do NOT pass page_properties to createPage. Logseq converts that argument with
+        // cljs-bean's ->clj, which yields a lazy Bean view rather than a real map, and
+        // stores it as the page entity's :block/properties. transit cannot serialise a
+        // Bean, so from that moment on every graph persist throws
+        //   "Cannot write $cljs_bean$core$Bean$$"
+        // and, because the main process has no handler for the resulting
+        // "persistent-dbs-error" reply, Logseq can never be closed again for the rest of
+        // the session. See logseq/logseq#8536.
+        //
+        // Writing the properties as the first block's content instead goes through
+        // Logseq's markdown property parser, which produces a genuine map. The resulting
+        // .md file is byte-identical to what the old call produced.
+        const newPage = await logseq.Editor.createPage(page_title, undefined, {
             format: "markdown",
             redirect: false,
             journal: false,
             createFirstBlock: false
         });
+
+        const propertyText = Object.entries(page_properties)
+            .map(([key, value]) => {
+                const rendered = (Array.isArray(value) ? value.join(", ") : value ?? "")
+                    .toString()
+                    .replace(/\r?\n/g, " ");
+                return rendered ? `${key}:: ${rendered}` : `${key}::`;
+            })
+            .join("\n");
+
+        if (propertyText) {
+            await logseq.Editor.appendBlockInPage(newPage?.uuid, propertyText);
+        }
 
         logseq.Editor.insertAtEditingCursor(`[[${page_title}]]`);
         logseq.Editor.exitEditingMode();


### PR DESCRIPTION
Fixes #16.

## What happens today

Adding a book makes Logseq's graph cache stop saving, and the app can no longer be closed for the
rest of the session — X, Quit and Ctrl/Cmd+Q all silently do nothing, with no dialog and no log line.

The underlying defect is in Logseq, not this plugin: `logseq.api/create_page` converts the
`properties` argument with `cljs-bean`'s `->clj`, which yields a lazy `Bean` view rather than a real
map, and stores it as the page entity's `:block/properties`. `datascript-transit` has no write
handler for a `Bean`, so from then on every graph persist throws:

```
Error: Cannot write $cljs_bean$core$Bean$$
    at com.cognitect.transit.impl.writer/marshal
    ... frontend.db.utils/db->string ... frontend.db/persist!
```

and Logseq's close handler waits forever for a save confirmation that never arrives.

That's [logseq/logseq#8536](https://github.com/logseq/logseq/issues/8536), open upstream since 2023.
I've filed fixes for it at [logseq/og#42](https://github.com/logseq/og/pull/42) and
[logseq/og#43](https://github.com/logseq/og/pull/43), but until those ship (and reach everyone's
install) `createPage` with properties is unusable, and this plugin calls it on every book added.

On my machine the graph cache silently stopped being written for **eight days** before I noticed,
and the app sat unquittable for 2 days 16 hours.

## The change

Create the page without properties, then write the properties as the first block's content. That
goes through Logseq's markdown property parser, which produces a genuine map.

I verified the generated page file is **byte-identical** to what the current code produces — same 263
bytes, same page-property pre-block — while the graph persists cleanly:

| | Persist | Page markdown |
|---|---|---|
| current `createPage(title, props, …)` | **fails** — Bean in DB | 263 B |
| this change | ok | 263 B, identical |

Array values are joined with `", "` and newlines collapsed, so a stray newline in a calibre field
can't break the property block.

I also checked the alternative I first suggested in #16 — `createPage` then `upsertBlockProperty` per
key. Don't use it: it produces a `- ` bullet rather than a page-property pre-block, i.e. *block*
properties instead of *page* properties, which changes the file. This approach preserves the output.

## Not changed

The `addBlockInstead` branch is left alone. `insertBlock` also runs `bean/->clj` over its opts
internally, but the block path renders properties into markdown as `a:: b` and re-parses them, so the
Bean is transient and never reaches the DB. I tested it explicitly (with `createPage(name, {a:'b'})`
as a positive control to make sure the test could detect the bug at all):

| Call | Graph persists |
|---|---|
| `createPage(name, {a:'b'})` — control | **no** |
| `insertBlock(uuid, content, { properties })` | yes |
| `insertBatchBlock(uuid, [{content, properties}])` | yes |
| `appendBlockInPage(page, content, { properties })` | yes |

So only the `createPage` branch needed changing. Sorry for flagging the `insertBlock` one as a
suspect in #16 before I'd tested it.

## Testing

Built with `npm run build` and installed into a real Logseq 0.10.15 (Flathub) with a 5228-page graph;
the plugin loads and the page output is unchanged. Note `dist/` is gitignored here, so this diff is
source-only and the released bundle will come from your normal release flow.
